### PR TITLE
BREAKING: Rename "collection" to "choices" for better semantics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    phlexi-form (0.4.7)
+    phlexi-form (0.5.0)
       activesupport
       phlex (~> 1.11)
       phlexi-field

--- a/lib/phlexi/form/builder.rb
+++ b/lib/phlexi/form/builder.rb
@@ -8,7 +8,7 @@ module Phlexi
       include Options::Validators
       include Options::InferredTypes
       include Options::Errors
-      include Options::Collection
+      include Options::Choices
       include Options::Hints
       include Options::Required
       include Options::Autofocus

--- a/lib/phlexi/form/components/collection_checkboxes.rb
+++ b/lib/phlexi/form/components/collection_checkboxes.rb
@@ -6,15 +6,15 @@ module Phlexi
       class CollectionCheckboxes < Base
         include Concerns::HandlesInput
         include Concerns::HandlesArrayInput
-        include Concerns::HasOptions
+        include Concerns::AcceptsChoices
 
         def view_template
           div(**attributes.slice(:id, :class)) do
-            field.repeated(option_mapper.values) do |builder|
+            field.repeated(choices.values) do |builder|
               render builder.hidden_field_tag if builder.index == 0
 
               field = builder.field(
-                label: option_mapper[builder.key],
+                label: choices[builder.key],
                 # We set the attributes here so they are applied to all input components even if the user decides to use a block
                 input_attributes: {
                   checked_value: builder.key,

--- a/lib/phlexi/form/components/collection_radio_buttons.rb
+++ b/lib/phlexi/form/components/collection_radio_buttons.rb
@@ -5,15 +5,15 @@ module Phlexi
     module Components
       class CollectionRadioButtons < Base
         include Concerns::HandlesInput
-        include Concerns::HasOptions
+        include Concerns::AcceptsChoices
 
         def view_template
           div(**attributes.slice(:id, :class)) do
-            field.repeated(option_mapper.values) do |builder|
+            field.repeated(choices.values) do |builder|
               render builder.hidden_field_tag if builder.index == 0
 
               field = builder.field(
-                label: option_mapper[builder.key],
+                label: choices[builder.key],
                 # We set the attributes here so they are applied to all input components even if the user decides to use a block
                 input_attributes: {
                   checked_value: builder.key,

--- a/lib/phlexi/form/components/concerns/accepts_choices.rb
+++ b/lib/phlexi/form/components/concerns/accepts_choices.rb
@@ -4,18 +4,18 @@ module Phlexi
   module Form
     module Components
       module Concerns
-        module HasOptions
+        module AcceptsChoices
           protected
 
           def build_attributes
             super
-            @collection = attributes.delete(:collection) || field.collection
+            @choice_collection = attributes.delete(:choices) || field.choices
             @label_method = attributes.delete(:label_method)
             @value_method = attributes.delete(:value_method)
           end
 
-          def option_mapper
-            @option_mapper ||= OptionMapper.new(@collection, label_method: @label_method, value_method: @value_method)
+          def choices
+            @choices ||= ChoicesMapper.new(@choice_collection, label_method: @label_method, value_method: @value_method)
           end
 
           def selected?(option)
@@ -28,7 +28,7 @@ module Phlexi
           end
 
           def normalize_simple_input(input_value)
-            ([super] & option_mapper.values)[0]
+            ([super] & choices.values)[0]
           end
         end
       end

--- a/lib/phlexi/form/components/select.rb
+++ b/lib/phlexi/form/components/select.rb
@@ -6,7 +6,7 @@ module Phlexi
       class Select < Base
         include Concerns::HandlesInput
         include Concerns::HandlesArrayInput
-        include Concerns::HasOptions
+        include Concerns::AcceptsChoices
 
         def view_template
           input(type: :hidden, name: attributes[:name], value: "", autocomplete: "off", hidden: true) if include_hidden?
@@ -19,7 +19,7 @@ module Phlexi
         protected
 
         def options
-          option_mapper.each do |value, label|
+          choices.each do |value, label|
             option(selected: selected?(value), value: value) { label }
           end
         end

--- a/lib/phlexi/form/options/choices.rb
+++ b/lib/phlexi/form/options/choices.rb
@@ -3,27 +3,27 @@
 module Phlexi
   module Form
     module Options
-      module Collection
-        def collection(collection = nil)
-          if collection.nil?
-            options.fetch(:collection) { options[:collection] = infer_collection }
+      module Choices
+        def choices(choices = nil)
+          if choices.nil?
+            options.fetch(:choices) { options[:choices] = infer_choices }
           else
-            options[:collection] = collection
+            options[:choices] = choices
             self
           end
         end
 
         private
 
-        def infer_collection
+        def infer_choices
           if object.class.respond_to?(:defined_enums)
             return object.class.defined_enums.fetch(key.to_s).keys if object.class.defined_enums.key?(key.to_s)
           end
 
-          collection_value_from_association || collection_value_from_validator
+          choices_from_association || choices_from_validator
         end
 
-        def collection_value_from_association
+        def choices_from_association
           return unless association_reflection
 
           relation = association_reflection.klass.all
@@ -46,7 +46,7 @@ module Phlexi
           relation
         end
 
-        def collection_value_from_validator
+        def choices_from_validator
           return unless has_validators?
 
           inclusion_validator = find_validator(:inclusion)

--- a/lib/phlexi/form/version.rb
+++ b/lib/phlexi/form/version.rb
@@ -2,6 +2,6 @@
 
 module Phlexi
   module Form
-    VERSION = "0.4.7"
+    VERSION = "0.5.0"
   end
 end

--- a/test/phlexi/form/builder_test.rb
+++ b/test/phlexi/form/builder_test.rb
@@ -58,13 +58,13 @@ module Phlexi
       end
 
       def test_collection_checkboxes_tag
-        field = Builder.new(:interests, parent: @parent, object: @object, collection: %w[Sports Music Art])
+        field = Builder.new(:interests, parent: @parent, object: @object, choices: %w[Sports Music Art])
         collection_checkboxes = field.collection_checkboxes_tag
         assert_instance_of Components::CollectionCheckboxes, collection_checkboxes
       end
 
       def test_collection_radio_buttons_tag
-        field = Builder.new(:favorite_color, parent: @parent, object: @object, collection: %w[Red Green Blue])
+        field = Builder.new(:favorite_color, parent: @parent, object: @object, choices: %w[Red Green Blue])
         collection_radio_buttons = field.collection_radio_buttons_tag
         assert_instance_of Components::CollectionRadioButtons, collection_radio_buttons
       end

--- a/test/phlexi/form/components/select_test.rb
+++ b/test/phlexi/form/components/select_test.rb
@@ -71,7 +71,7 @@ module Phlexi
         def test_that_it_renders_select_options
           render Phlexi::Form(:user) {
             render field(:name)
-              .collection(1..5)
+              .choices(1..5)
               .select_tag
           }
 
@@ -87,7 +87,7 @@ module Phlexi
         def test_that_it_selects_single_option
           render Phlexi::Form(:user) {
             render field(:name, value: 4)
-              .collection(1..5)
+              .choices(1..5)
               .select_tag
           }
 
@@ -99,7 +99,7 @@ module Phlexi
           render Phlexi::Form(:user) {
             render field(:name, value: [2, 4])
               .multiple!
-              .collection(1..5)
+              .choices(1..5)
               .select_tag
           }
 
@@ -111,7 +111,7 @@ module Phlexi
 
         def test_that_it_extracts_single_option
           form = Phlexi::Form(:user) {
-            render field(:name).collection(1..5).select_tag
+            render field(:name).choices(1..5).select_tag
           }
 
           assert_equal({user: {name: "1"}}, form.extract_input({user: {name: "1"}}))
@@ -123,7 +123,7 @@ module Phlexi
 
         def test_that_it_extracts_multiple_options
           form = Phlexi::Form(:user) {
-            render field(:name, collection: 1..5).select_tag(multiple: true)
+            render field(:name, choices: 1..5).select_tag(multiple: true)
           }
 
           assert_equal({user: {name: ["1"]}}, form.extract_input({user: {name: "1"}}))

--- a/test/phlexi/form_test.rb
+++ b/test/phlexi/form_test.rb
@@ -83,8 +83,8 @@ module Phlexi
         render field(:select).select_tag
         render field(:checkbox).checkbox_tag
         render field(:radio).radio_button_tag
-        render field(:collection_checkboxes, collection: 1..2).collection_checkboxes_tag
-        render field(:collection_radio_buttons, collection: 1..2).collection_radio_buttons_tag
+        render field(:collection_checkboxes, choices: 1..2).collection_checkboxes_tag
+        render field(:collection_radio_buttons, choices: 1..2).collection_radio_buttons_tag
         render field(:input_array, value: 1..2).input_array_tag
       end.call
       expected = '<form id="user_1" method="post" accept-charset="UTF-8"><label class="label optional" id="user_1_field_label" for="user_1_field">Field</label><input class="input optional" id="user_1_field" name="user[field]" value="" type="text"><textarea class="textarea optional" id="user_1_textarea" name="user[textarea]"></textarea><select class="select optional" id="user_1_select" name="user[select]"><option selected></option></select><input type="hidden" name="user[checkbox]" value="0" autocomplete="off" hidden><input class="checkbox optional" id="user_1_checkbox" name="user[checkbox]" value="1" type="checkbox"><input class="radio_button optional" id="user_1_radio" name="user[radio]" value="1" type="radio"><div id="user_1_collection_checkboxes" class="collection_checkboxes optional"><input type="hidden" value="" id="user_1_collection_checkboxes_hidden" name="user[collection_checkboxes][]" hidden autocomplete="off"><input class="checkbox optional" id="user_1_collection_checkboxes_1" name="user[collection_checkboxes][]" value="1" type="checkbox"><label class="label optional" id="user_1_collection_checkboxes_1_label" for="user_1_collection_checkboxes_1">1</label><input class="checkbox optional" id="user_1_collection_checkboxes_2" name="user[collection_checkboxes][]" value="2" type="checkbox"><label class="label optional" id="user_1_collection_checkboxes_2_label" for="user_1_collection_checkboxes_2">2</label></div><div id="user_1_collection_radio_buttons" class="collection_radio_buttons optional"><input type="hidden" value="" id="user_1_collection_radio_buttons_hidden" name="user[collection_radio_buttons][]" hidden autocomplete="off"><input class="radio_button optional" id="user_1_collection_radio_buttons_1" name="user[collection_radio_buttons]" value="1" type="radio"><label class="label optional" id="user_1_collection_radio_buttons_1_label" for="user_1_collection_radio_buttons_1">1</label><input class="radio_button optional" id="user_1_collection_radio_buttons_2" name="user[collection_radio_buttons]" value="2" type="radio"><label class="label optional" id="user_1_collection_radio_buttons_2_label" for="user_1_collection_radio_buttons_2">2</label></div><div id="user_1_input_array" class="input_array optional"><input type="hidden" value="" id="user_1_input_array_hidden" name="user[input_array][]" hidden autocomplete="off"><input class="input optional" id="user_1_input_array_1" name="user[input_array][]" value="1" type="text"><input class="input optional" id="user_1_input_array_2" name="user[input_array][]" value="2" type="text"></div></form>'
@@ -116,13 +116,13 @@ module Phlexi
         render field(:unchecked_radio).radio_button_tag
         render field(:invalid_radio).radio_button_tag
 
-        render field(:select).select_tag(collection: 1..5)
-        render field(:invalid_select).select_tag(collection: 1..5)
-        render field(:multi_select).select_tag(collection: 1..5, multiple: true)
+        render field(:select).select_tag(choices: 1..5)
+        render field(:invalid_select).select_tag(choices: 1..5)
+        render field(:multi_select).select_tag(choices: 1..5, multiple: true)
 
-        render field(:collection_checkboxes, collection: 1..5).collection_checkboxes_tag
-        render field(:collection_radio_buttons, collection: 1..5).collection_radio_buttons_tag
-        render field(:invalid_collection_radio_buttons, collection: 1..5).collection_radio_buttons_tag
+        render field(:collection_checkboxes, choices: 1..5).collection_checkboxes_tag
+        render field(:collection_radio_buttons, choices: 1..5).collection_radio_buttons_tag
+        render field(:invalid_collection_radio_buttons, choices: 1..5).collection_radio_buttons_tag
 
         render field(:input_param, input_attributes: {input_param: :custom_input_param}).input_tag
 


### PR DESCRIPTION
This PR renames our "collection" concept to "choices" throughout the form components. The change aims to:

1. Use more intuitive terminology - "choices" better describes what these options represent from a user's perspective (e.g. choices in a select box or radio button group)

2. Improve API consistency - Renames related concepts to align with this change:
   - `collection` → `choices` 
   - `OptionMapper` → `ChoicesMapper`
   - `HasOptions` → `AcceptsChoices`

3. Better alignment with modern form libraries - Many modern form libraries use "choices" rather than "collection" for describing selectable options

Breaking Changes:
- Rename `.collection()` to `.choices()` on form builders
- Rename any uses of `collection:` parameter to `choices:` in form configurations
- The `OptionMapper` class is now `ChoicesMapper`

Example usage:

```ruby
# Before
field(:status).collection([:draft, :published]).select_tag

# After  
field(:status).choices([:draft, :published]).select_tag