### PR TITLE
automatically add multipart/form-data encoding for forms with file inputs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    phlexi-form (0.5.1)
+    phlexi-form (0.5.2)
       activesupport
       phlex (~> 1.11)
       phlexi-field

--- a/lib/phlexi/form/base.rb
+++ b/lib/phlexi/form/base.rb
@@ -34,7 +34,7 @@ module Phlexi
 
       attr_reader :key, :object
 
-      delegate :field, :submit_button, :nest_one, :nest_many, to: :@namespace
+      delegate :field, :submit_button, :nest_one, :nest_many, :has_file_input?, to: :@namespace
 
       # Initializes a new Form instance.
       #
@@ -65,10 +65,18 @@ module Phlexi
       #
       # @return [void]
       def view_template(&)
-        form_tag {
+        captured = capture { form_template(&) }
+        form_tag do
           form_errors
-          form_template(&)
-        }
+          plain(captured)
+        end
+
+        # TODO: phlex v2
+        # captured = capture { form_template(&) }
+        # form_tag do
+        #   form_errors
+        #   raw(safe(captured))
+        # end
       end
 
       def form_errors
@@ -254,12 +262,14 @@ module Phlexi
       #
       # @return [Hash] The form attributes
       def form_attributes
-        mix({
+        attrs = mix({
           id: @namespace.dom_id,
           class: form_class,
           action: form_action,
           method: standardized_form_method
         }, attributes)
+        attrs[:enctype] ||= "multipart/form-data" if has_file_input?
+        attrs
       end
 
       # Renders the authenticity token if required.

--- a/lib/phlexi/form/builder.rb
+++ b/lib/phlexi/form/builder.rb
@@ -4,7 +4,6 @@ module Phlexi
   module Form
     # Builder class is responsible for building form fields with various options and components.
     class Builder < Phlexi::Field::Builder
-      include Phlexi::Form::Structure::HasFields
       include Phlexi::Form::HTML::Behaviour
       include Options::Validators
       include Options::InferredTypes
@@ -250,10 +249,17 @@ module Phlexi
         @field_input_extractor.extract_input(params)
       end
 
+      def has_file_input!
+        parent.has_file_input!
+      end
+
       protected
 
       def create_component(component_class, theme_key, **attributes, &)
         theme_attributes = apply_component_theme(attributes, theme_key)
+        # TODO: refactor all this type checking code such that, the concerns will perform these actions.
+        # Basically, invert control so that the component asks for the extra attributes
+        # or calls #has_file_input!
         extra_attributes = if component_class.include?(Phlexi::Form::Components::Concerns::HandlesInput)
           input_attributes
         else

--- a/lib/phlexi/form/builder.rb
+++ b/lib/phlexi/form/builder.rb
@@ -4,6 +4,7 @@ module Phlexi
   module Form
     # Builder class is responsible for building form fields with various options and components.
     class Builder < Phlexi::Field::Builder
+      include Phlexi::Form::Structure::HasFields
       include Phlexi::Form::HTML::Behaviour
       include Options::Validators
       include Options::InferredTypes
@@ -260,10 +261,11 @@ module Phlexi
         end
         attributes = mix(theme_attributes, extra_attributes, attributes)
         component = component_class.new(self, **attributes, &)
-        if component_class.include?(Components::Concerns::ExtractsInput)
+        if component_class.include?(Components::Concerns::ExtractsInput) 
           raise "input component already defined: #{@field_input_extractor.inspect}" if @field_input_extractor
 
           @field_input_extractor = component
+          has_file_input! if component_class.include?(Components::Concerns::UploadsFile)
         end
 
         component

--- a/lib/phlexi/form/components/concerns/uploads_file.rb
+++ b/lib/phlexi/form/components/concerns/uploads_file.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Phlexi
+  module Form
+    module Components
+      module Concerns
+        module UploadsFile
+        end
+      end
+    end
+  end
+end

--- a/lib/phlexi/form/components/file_input.rb
+++ b/lib/phlexi/form/components/file_input.rb
@@ -4,6 +4,8 @@ module Phlexi
   module Form
     module Components
       class FileInput < Input
+        include Phlexi::Form::Components::Concerns::UploadsFile
+
         def view_template
           input(type: :hidden, name: attributes[:name], value: "", autocomplete: "off", hidden: true) if include_hidden?
           input(**attributes)

--- a/lib/phlexi/form/structure/has_fields.rb
+++ b/lib/phlexi/form/structure/has_fields.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Phlexi
+  module Form
+    module Structure
+      module HasFields
+        def has_file_input!
+          if parent
+           parent.has_file_input!
+          else
+            @has_file_input = true
+          end
+        end
+
+        def has_file_input?
+          if parent
+           parent.has_file_input?
+          else
+            @has_file_input || false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/phlexi/form/structure/manages_fields.rb
+++ b/lib/phlexi/form/structure/manages_fields.rb
@@ -3,7 +3,7 @@
 module Phlexi
   module Form
     module Structure
-      module HasFields
+      module ManagesFields
         def has_file_input!
           if parent
            parent.has_file_input!

--- a/lib/phlexi/form/structure/namespace.rb
+++ b/lib/phlexi/form/structure/namespace.rb
@@ -4,7 +4,7 @@ module Phlexi
   module Form
     module Structure
       class Namespace < Phlexi::Field::Structure::Namespace
-        include Phlexi::Form::Structure::HasFields
+        include Phlexi::Form::Structure::ManagesFields
         
         class NamespaceCollection < Phlexi::Form::Structure::NamespaceCollection; end
 

--- a/lib/phlexi/form/structure/namespace.rb
+++ b/lib/phlexi/form/structure/namespace.rb
@@ -4,6 +4,8 @@ module Phlexi
   module Form
     module Structure
       class Namespace < Phlexi::Field::Structure::Namespace
+        include Phlexi::Form::Structure::HasFields
+        
         class NamespaceCollection < Phlexi::Form::Structure::NamespaceCollection; end
 
         def submit_button(key = :submit_button, **, &)

--- a/lib/phlexi/form/structure/namespace_collection.rb
+++ b/lib/phlexi/form/structure/namespace_collection.rb
@@ -4,6 +4,8 @@ module Phlexi
   module Form
     module Structure
       class NamespaceCollection < Phlexi::Field::Structure::NamespaceCollection
+        include Phlexi::Form::Structure::HasFields
+        
         def extract_input(params)
           namespace = build_namespace(0)
           @block.call(namespace)

--- a/lib/phlexi/form/structure/namespace_collection.rb
+++ b/lib/phlexi/form/structure/namespace_collection.rb
@@ -4,7 +4,7 @@ module Phlexi
   module Form
     module Structure
       class NamespaceCollection < Phlexi::Field::Structure::NamespaceCollection
-        include Phlexi::Form::Structure::HasFields
+        include Phlexi::Form::Structure::ManagesFields
         
         def extract_input(params)
           namespace = build_namespace(0)

--- a/lib/phlexi/form/version.rb
+++ b/lib/phlexi/form/version.rb
@@ -2,6 +2,6 @@
 
 module Phlexi
   module Form
-    VERSION = "0.5.1"
+    VERSION = "0.5.2"
   end
 end


### PR DESCRIPTION
This PR automatically sets the appropriate form encoding type when file inputs are present, while also improving form template handling and code organization.

Key changes:
- Automatically set `enctype="multipart/form-data"` when a form contains file inputs
- Introduce `UploadsFile` concern for file input components

The main benefit is that developers no longer need to manually set `enctype="multipart/form-data"` when creating forms with file uploads - it's now handled automatically when a FileInput component is detected.